### PR TITLE
Improvement/StringIndex

### DIFF
--- a/lib/Catalog/Catalog.js
+++ b/lib/Catalog/Catalog.js
@@ -23,14 +23,10 @@
 
 		// Indexes used for category search
 		this.categoriesIdIndex = {};
-		this.categoriesObjectTypeIndex = {};
-		this.categoriesStatNameIndex = {};
 		this.categoriesStringIndex = {};
 
 		// Indexes used for metric search
 		this.metricsIdIndex = {};
-		this.metricsCategoryIdIndex = {};
-		this.metricsFieldNameIndex = {};
 		this.metricsStringIndex = {};
 	};
 

--- a/lib/Catalog/Catalog.js
+++ b/lib/Catalog/Catalog.js
@@ -25,11 +25,13 @@
 		this.categoriesIdIndex = {};
 		this.categoriesObjectTypeIndex = {};
 		this.categoriesStatNameIndex = {};
+		this.categoriesStringIndex = {};
 
 		// Indexes used for metric search
 		this.metricsIdIndex = {};
 		this.metricsCategoryIdIndex = {};
 		this.metricsFieldNameIndex = {};
+		this.metricsStringIndex = {};
 	};
 
 	/**
@@ -104,13 +106,18 @@
 	 * @return Category
 	 */
 	Catalog.prototype.getCategoryByStatString = function(statString){
+		var category = new Category();
+		var categoryArray = [];
+		var lookupValues = [];
+		var lookupString = '';
+
 		// Validate string
 		if(typeof statString !== 'string'){
 			throw new Error("Error: Invalid argument type passed to getCategoryByStatString - " + statString);
 		}
 
 		// Split string
-		var lookupValues = statString.split('.');
+		lookupValues = statString.split('.');
 
 		// Drop prefix since it's not used
 		lookupValues.shift();
@@ -120,26 +127,16 @@
 			throw new Error("Error: Inavlid string provided for category lookup - " + statString);
 		}
 
-		// Lookup matching object_type, time is O(1)
-		var objectTypeMatches = this.categoriesObjectTypeIndex[lookupValues[0]];
+		// Recombine lookup values into identifying string
+		lookupString = lookupValues[0] + '.' + lookupValues[1];
 
-		// Lookup matching stat_name, time is O(1)
-		var statNameMatches = this.categoriesStatNameIndex[lookupValues[1]];
-
-		// Find the intersect
-		var intersection = this._arrayIntersect(objectTypeMatches, statNameMatches);
-
-		// Validate results and return
-		if(intersection.length === 0){
-			throw new Error("Error: No matches for string provided for category lookup - " + statString);
-		} else if(intersection.length > 1){
-			throw new Error("Error: Multiple matches returned for string provided for category lookup - " + statString);
-		} else {
-			// Populate category model and return
-			var category = new Category();
-			category.populateFromArray(this.categories[intersection[0]]);
-			return category;
-		}
+		// Attempt to find category
+		if(lookupString in this.categoriesStringIndex){
+			categoryArray = this.categories[this.categoriesStringIndex[lookupString]];
+			category.populateFromArray(categoryArray);
+		} 
+			
+		return category;
 	};
 
 	/**
@@ -167,42 +164,38 @@
 	 * @return Metric
 	 */
 	Catalog.prototype.getMetricByStatString = function(statString){
+		var metric = new Metric();
+		var metricArray = [];
+		var lookupValues = [];
+		var lookupString = '';
+		
+
 		// Validate string
 		if(typeof statString !== 'string'){
 			throw new Error("Error: Invalid argument type passed to getMetricByStatString - " + statString);
 		}
 
 		// Split string at category/metric divide
-		var lookupValues = statString.split(':');
+		lookupValues = statString.split('.');
+
+		// Drop metric namespace value
+		lookupValues.shift();
 
 		// validate number of arguments
 		if(lookupValues.length !== 2){
 			throw new Error("Error: Inavlid string provided for metric lookup - " + statString);
 		}
-		
-		// Lookup matching category first
-		var category = this.getCategoryByStatString(lookupValues[0]);
 
-		// Pull metrics that match category
-		var categoryIdMatches = this.metricsCategoryIdIndex[category.id];
+		// Recombine lookup values into identifying string
+		lookupString = lookupValues[0] + '.' + lookupValues[1];
 
-		// Pull metrics that match field name
-		var fieldNameMatches = this.metricsFieldNameIndex[lookupValues[1]];
+		// Attempt to find category
+		if(lookupString in this.metricsStringIndex){
+			metricArray = this.metrics[this.metricsStringIndex[lookupString]];
+			metric.populateFromArray(metricArray);
+		} 
 
-		// Find the intersect
-		var intersection = this._arrayIntersect(categoryIdMatches, fieldNameMatches);
-
-		// Validate results and return
-		if(intersection.length === 0){
-			throw new Error("Error: No matches for string provided for metric lookup - " + statString);
-		} else if(intersection.length > 1){
-			throw new Error("Error: Multiple matches returned for string provided for metric lookup - " + statString);
-		} else {
-			// Populate Metric object and return
-			var metric = new Metric();
-			metric.populateFromArray(this.metrics[intersection[0]]);
-			return metric;
-		}
+		return metric;
 	};
 
 	/**
@@ -211,7 +204,7 @@
 	 */
 	Catalog.prototype._buildCategoriesIndexes = function(){
 		// Declare local variables
-		var currentId, currentObjectType, currentStatName;
+		var currentId, currentObjectType, currentStatName, stringIndex;
 
 		// Indexing for faster search
 		// Time is O(n)
@@ -225,21 +218,11 @@
 			// Useful if ID doesn't match index
 			this.categoriesIdIndex[currentId] = i; 
 
-			// Object types aren't necessarily unique
-			// Provide an array of matching indexes into the categories array
-			if(currentObjectType in this.categoriesObjectTypeIndex){
-		        this.categoriesObjectTypeIndex[currentObjectType].push(i);
-		    } else {
-		        this.categoriesObjectTypeIndex[currentObjectType] = [i];
-		    }
+			// Unique string identifier consists of object_type.stat_name
+			stringIndex = currentObjectType + '.' + currentStatName;
 
-			// Stat names aren't necessarily unique
-			// Provide an array of matching indexes into the categories array
-			if(currentStatName in this.categoriesStatNameIndex){
-		        this.categoriesStatNameIndex[currentStatName].push(i);
-		    } else {
-		        this.categoriesStatNameIndex[currentStatName] = [i];
-		    }
+			// Provide unique string index lookup
+			this.categoriesStringIndex[stringIndex] = i;
 		}
 	};
 
@@ -249,7 +232,7 @@
 	 */
 	Catalog.prototype._buildMetricsIndexes = function(){
 		// Declare local variables
-		var currentId, currentCategoryId, currentFieldName;
+		var currentId, currentCategoryId, currentFieldName, category, stringIndex;
 		
 		// indexing for faster search
 		// Time is O(n)
@@ -263,21 +246,14 @@
 			// Useful if ID doesn't match index
 			this.metricsIdIndex[currentId] = i; 
 
-			// More than one metric can belong to the same category
-			// Provide an array of matching indexes into the metrics array
-			if(currentCategoryId in this.metricsCategoryIdIndex){
-				this.metricsCategoryIdIndex[currentCategoryId].push(i);
-			} else {
-				this.metricsCategoryIdIndex[currentCategoryId] = [i];
-			}
+			// Retrieve the associated category
+			category = this.getCategoryById(currentCategoryId);
 
-			// Field names aren't necessarily unique
-			// Provide an array of matching indexes into the metrics array
-			if(currentFieldName in this.metricsFieldNameIndex){
-				this.metricsFieldNameIndex[currentFieldName].push(i);
-			} else {
-				this.metricsFieldNameIndex[currentFieldName] = [i];
-			}
+			// Unique string identifier consists of object_type.stat_name:field_name
+			stringIndex = category.object_type + '.' + category.stat_name + ':' + currentFieldName;
+
+			// Provide unique string index lookup
+			this.metricsStringIndex[stringIndex] = i;
 		}
 	};
 


### PR DESCRIPTION
This should change all string lookups to a O(1) operation instead of the previous O(log n) operation. Memory usage is slimmed some by maintaining fewer overall indexes.

Possible loss of future functionality if it becomes necessary to search for categories by object_type or stat_name alone.
